### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 для работы надо заполнить параметры в ansible/group_vars/all.yml
 
-+ domain - твой арендованый домен
++ domain - твой арендованный домен
 + trojan_password - придумай пароль для vpn
 + ansible_user/ansible_ssh_pass - креды твоего арендованного vps 
 + Дополнительно указать ip твоего VPS в inventory.ini


### PR DESCRIPTION
## Summary
- fix typo 'арендованый' -> 'арендованный'

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870a91210dc83289d2721f9f6d5fac2