### PR TITLE
Fix leaderboard fetch effect

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -45,7 +45,9 @@ function App() {
 
   useEffect(() => {
     fetch('/api/scores').then(res => res.json()).then(setLeaderboard);
+  }, []);
 
+  useEffect(() => {
     const decayInterval = setInterval(() => {
       const now = Date.now();
       const idleTime = now - lastClickTimeRef.current;


### PR DESCRIPTION
## Summary
- fix leaderboard fetch effect to only run on mount

## Testing
- `npm run build` *(fails: vite not found)*
- `npm start` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68510266e6a08328a303838cba0ea0b9