### PR TITLE
fix(frontend): reintroduce resetProgress

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -191,6 +191,14 @@ function App() {
     }).then(res => res.json()).then(setLeaderboard);
   };
 
+  const resetProgress = () => {
+    localStorage.removeItem('playerName');
+    localStorage.removeItem('score');
+    localStorage.removeItem('unlocked');
+    setScore(0);
+    setUnlocked(new Set());
+  };
+
   return (
     <div className="container">
       {!started ? (


### PR DESCRIPTION
## Summary
- restore the missing `resetProgress` function in `App.jsx`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68715f118c0c8328a058101605c5183f