### PR TITLE
Remove reset progress feature

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -191,13 +191,6 @@ function App() {
     }).then(res => res.json()).then(setLeaderboard);
   };
 
-  const resetProgress = () => {
-    localStorage.removeItem('playerName');
-    localStorage.removeItem('score');
-    localStorage.removeItem('unlocked');
-    setScore(0);
-    setUnlocked(new Set());
-  };
 
   return (
     <div className="container">
@@ -262,7 +255,6 @@ function App() {
           </div>
 
           <button onClick={submitScore} disabled={score === 0}>Отправить результат</button>
-          <button onClick={resetProgress}>Сбросить прогресс</button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- delete the unused `resetProgress` handler
- remove the Reset Progress button from the game UI

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687161519e408328969b31053ef75924